### PR TITLE
Reference: Show failure notification

### DIFF
--- a/ReferenceAdapter/src/main/java/com/chartboost/helium/referenceadapter/adapter/ReferenceAdapter.kt
+++ b/ReferenceAdapter/src/main/java/com/chartboost/helium/referenceadapter/adapter/ReferenceAdapter.kt
@@ -35,7 +35,7 @@ class ReferenceAdapter : PartnerAdapter {
      * Override this value to return the version of the partner SDK.
      */
     override val partnerSdkVersion: String
-        get() = ReferenceSdk.getVersion()
+        get() = ReferenceSdk.REFERENCE_SDK_VERSION
 
     /**
      * Override this value to return the version of the mediation adapter.
@@ -357,8 +357,11 @@ class ReferenceAdapter : PartnerAdapter {
                                 "Unable to notify partner ad impression. Listener is null."
                             )
 
-                            // For simplicity, the reference adapter always assumes successes.
                             continuation.resume(Result.success(partnerAd))
+                        },
+                        onFullScreenAdShowFailed = {
+                            PartnerLogController.log(SHOW_FAILED, it)
+                            continuation.resume(Result.failure(HeliumAdException(HeliumErrorCode.INTERNAL)))
                         },
                         onFullScreenAdDismissed = {
                             listener?.let {
@@ -393,7 +396,7 @@ class ReferenceAdapter : PartnerAdapter {
                                 )
                             }
                         },
-                        onFullScreenAdExpired = { error ->
+                        onFullScreenAdExpired = {
                             listener?.let {
                                 PartnerLogController.log(DID_EXPIRE)
                                 it.onPartnerAdExpired(partnerAd)

--- a/ReferenceAdapter/src/main/java/com/chartboost/helium/referenceadapter/sdk/ReferenceBanner.kt
+++ b/ReferenceAdapter/src/main/java/com/chartboost/helium/referenceadapter/sdk/ReferenceBanner.kt
@@ -82,9 +82,8 @@ class ReferenceBanner(
     }
 
     private fun clickthrough() {
-        val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(clickThroughUrl)).apply {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(clickThroughUrl)).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-        context.startActivity(browserIntent)
+        })
     }
 }

--- a/ReferenceAdapter/src/main/java/com/chartboost/helium/referenceadapter/sdk/ReferenceSdk.kt
+++ b/ReferenceAdapter/src/main/java/com/chartboost/helium/referenceadapter/sdk/ReferenceSdk.kt
@@ -10,11 +10,7 @@ import java.util.*
  */
 class ReferenceSdk {
     companion object {
-        private const val REFERENCE_SDK_VERSION = "1.0.0"
-
-        fun getVersion(): String {
-            return REFERENCE_SDK_VERSION
-        }
+        const val REFERENCE_SDK_VERSION = "1.0.0"
 
         /**
          * Simulate a partner SDK initialization that does nothing and completes after 500 ms.
@@ -25,7 +21,7 @@ class ReferenceSdk {
         }
 
         /**
-         * Simulate a partner SDK computation of a big token.
+         * Simulate a partner SDK computation of a bid token.
          * Using the random UUID as an example. Do NOT copy.
          */
         fun getBidToken(): String {


### PR DESCRIPTION
Primary change is piping show failures from the Activity all the way back to the adapter, so that show failures can be appropriately handled by Helium. Previously, show failures were not handled and show would just time out.