### PR TITLE
Add option to resume continuation multiple times for load and/or show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.1.0.1.0
+- Added setting to resume continuation multiple times for load and/or show for testing purposes.
+
 ### 4.1.0.0.4
 - Added setting to close fullscreen ads with an optional error.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Reference adapter mediates the Reference SDK via the Ch
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-reference:4.1.0.0.4"
+    implementation "com.chartboost:chartboost-mediation-adapter-reference:4.1.0.1.0"
 ```
 
 ## Contributions

--- a/ReferenceAdapter/build.gradle.kts
+++ b/ReferenceAdapter/build.gradle.kts
@@ -34,7 +34,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.1.0.0.4"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.1.0.1.0"
         buildConfigField("String", "CHARTBOOST_MEDIATION_REFERENCE_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/ReferenceAdapter/src/main/java/com/chartboost/mediation/referenceadapter/sdk/ReferenceFullscreenActivity.kt
+++ b/ReferenceAdapter/src/main/java/com/chartboost/mediation/referenceadapter/sdk/ReferenceFullscreenActivity.kt
@@ -33,6 +33,10 @@ import com.chartboost.mediation.referenceadapter.R
 import com.chartboost.mediation.referenceadapter.databinding.ActivityReferenceFullscreenBinding
 import com.chartboost.mediation.referenceadapter.sdk.ReferenceFullscreenAd.Companion.FULLSCREEN_AD_TYPE
 import com.chartboost.mediation.referenceadapter.sdk.ReferenceFullscreenAd.Companion.FULLSCREEN_AD_URL
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers.Main
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * INTERNAL. FOR DEMO AND TESTING PURPOSES ONLY. DO NOT USE DIRECTLY.
@@ -223,7 +227,16 @@ class ReferenceFullscreenActivity : AppCompatActivity() {
                 ).also { it.start() }
             }
 
-            onAdShown()
+            // Simulate multiple continuation resumes for testing purposes. This should not crash.
+            if (ReferenceSettings.adShowContinuationShouldResumeMoreThanOnce) {
+                CoroutineScope(Main).launch {
+                    onAdShown()
+                    delay(500L)
+                    onAdShown()
+                }
+            } else {
+                onAdShown()
+            }
         }
     }
 

--- a/ReferenceAdapter/src/main/java/com/chartboost/mediation/referenceadapter/sdk/ReferenceSettings.kt
+++ b/ReferenceAdapter/src/main/java/com/chartboost/mediation/referenceadapter/sdk/ReferenceSettings.kt
@@ -17,9 +17,10 @@ object ReferenceSettings {
     private const val REFERENCE_ADAPTER_TOKEN_FETCH_STATUS = "REFERENCE_ADAPTER_TOKEN_FETCH_STATUS"
     private const val REFERENCE_ADAPTER_AD_LOAD_STATUS = "REFERENCE_ADAPTER_AD_LOAD_STATUS"
     private const val REFERENCE_ADAPTER_AD_SHOW_STATUS = "REFERENCE_ADAPTER_AD_SHOW_STATUS"
-    private const val REFERENCE_ADAPTER_AD_INVALIDATE_STATUS =
-        "REFERENCE_ADAPTER_AD_INVALIDATE_STATUS"
+    private const val REFERENCE_ADAPTER_AD_INVALIDATE_STATUS = "REFERENCE_ADAPTER_AD_INVALIDATE_STATUS"
     private const val REFERENCE_ADAPTER_AD_CLOSE_STATUS = "REFERENCE_ADAPTER_AD_CLOSE_STATUS"
+    private const val REFERENCE_ADAPTER_AD_LOAD_CONTINUATION_STATUS = "REFERENCE_ADAPTER_AD_LOAD_CONTINUATION_STATUS"
+    private const val REFERENCE_ADAPTER_AD_SHOW_CONTINUATION_STATUS = "REFERENCE_ADAPTER_AD_SHOW_CONTINUATION_STATUS"
 
     var initializationShouldSucceed: Boolean
         get() = getSetting(REFERENCE_ADAPTER_INIT_STATUS, true)
@@ -44,6 +45,14 @@ object ReferenceSettings {
     var adCloseShouldSucceed: Boolean
         get() = getSetting(REFERENCE_ADAPTER_AD_CLOSE_STATUS, true)
         set(value) = applySetting(REFERENCE_ADAPTER_AD_CLOSE_STATUS, value)
+
+    var adLoadContinuationShouldResumeMoreThanOnce: Boolean
+        get() = getSetting(REFERENCE_ADAPTER_AD_LOAD_CONTINUATION_STATUS, false)
+        set(value) = applySetting(REFERENCE_ADAPTER_AD_LOAD_CONTINUATION_STATUS, value)
+
+    var adShowContinuationShouldResumeMoreThanOnce: Boolean
+        get() = getSetting(REFERENCE_ADAPTER_AD_SHOW_CONTINUATION_STATUS, false)
+        set(value) = applySetting(REFERENCE_ADAPTER_AD_SHOW_CONTINUATION_STATUS, value)
 
     private fun getSetting(key: String, defaultValue: Boolean): Boolean {
         return appContext?.getSharedPreferences(REFERENCE_ADAPTER_SETTINGS, Context.MODE_PRIVATE)


### PR DESCRIPTION
This is an attempt to "prove" that the fix we've put in previously works in cases where there are multiple continuation resumes. It doesn't actually prevent the next adapters from having the same issue, nor does it replace any unit tests (not that there could be any for this type of issue) for the SDK.

Canary's configuration settings will follow in a separate PR